### PR TITLE
fix insert with compound keys and field name different from field db property

### DIFF
--- a/DataTables-Editor-Server/Editor.cs
+++ b/DataTables-Editor-Server/Editor.cs
@@ -795,7 +795,8 @@ namespace DataTables
                 }
                 else
                 {
-                    val = NestedData.ReadProp(column, row).ToString();
+                    var field = _FindField(column, "db");
+                    val = NestedData.ReadProp(field.Name(), row).ToString();
                 }
 
                 if (val == null)


### PR DESCRIPTION
PkeyToValue method doesn't consider that the field name could be different from the field db property.
In "non-flat version" (during insert with compound keys) it looks for property named as pkey[i] (db property) but it's doesn't find anything because the client uses field name.  