### PR TITLE
 upload and mjoin with non-dbo tables (child table)

### DIFF
--- a/DataTables-Editor-Server/MJoin.cs
+++ b/DataTables-Editor-Server/MJoin.cs
@@ -28,9 +28,8 @@ namespace DataTables
         public MJoin(string table)
         {
             Table(table);
-            Name(table);
+            Name(table.Split(new[] { '.' }).Last());
         }
-
 
         /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
          * Private parameters
@@ -384,7 +383,7 @@ namespace DataTables
                 {
                     query.Join(_table, _childField + " = " + _hostField);
                 }
-                
+
                 var readField = "";
                 var joinFieldName = _hostField.Split(new[] { '.' }).Last();
                 if (NestedData.InData(_hostField, response.data[0]))
@@ -422,7 +421,7 @@ namespace DataTables
 
                         foreach (var data in response.data)
                         {
-                            whereIn.Add( pkeyIsJoin
+                            whereIn.Add(pkeyIsJoin
                                 ? (data["DT_RowId"].ToString()).Replace(editor.IdPrefix(), "")
                                 : NestedData.ReadProp(readField, data).ToString()
                             );
@@ -506,12 +505,13 @@ namespace DataTables
                     // remove the table name from the field as some dbs (postgres)
                     // don't like it. Might be nicer to have the Database classes
                     // do this - todo
-                    var a = _childField.Split(new [] {'.'});
+                    var a = _childField.Split(new[] { '.' });
+
                     _editor.Db()
                         .Query("Insert")
                         .Table(_linkTable)
-                        .Set(_linkHostField.Split(new [] {'.'}).Last(), parentId)
-                        .Set(_linkChildField.Split(new [] {'.'}).Last(), dataSet[a[1]])
+                        .Set(_linkHostField.Split(new[] { '.' }).Last(), parentId)
+                        .Set(_linkChildField.Split(new[] { '.' }).Last(), dataSet[a.Last()])
                         .Exec();
                 }
                 else
@@ -519,13 +519,13 @@ namespace DataTables
                     var query = _editor.Db()
                         .Query("Insert")
                         .Table(_table)
-                        .Set(_childField.Split(new [] {'.'}).Last(), parentId);
+                        .Set(_childField.Split(new[] { '.' }).Last(), parentId);
 
                     foreach (var field in _fields)
                     {
                         if (field.Apply("set", dataSet))
                         {
-                            query.Set(field.DbField().Split(new [] {'.'}).Last(), field.Val("set", dataSet));
+                            query.Set(field.DbField().Split(new[] { '.' }).Last(), field.Val("set", dataSet));
                         }
                     }
 
@@ -611,9 +611,9 @@ namespace DataTables
             var list = data.ContainsKey(_name) ?
                 (Dictionary<string, object>)data[_name] :
                 new Dictionary<string, object>();
-            
+
             // Grouped validation
-            for (var i=0 ; i<_validators.Count() ; i++)
+            for (var i = 0; i < _validators.Count(); i++)
             {
                 var res = _validators[i](editor, action, list);
 
@@ -687,7 +687,7 @@ namespace DataTables
             // Resolve what field names belong to what varible for processing
             for (int i = 0, ien = _links.Count(); i < ien; i++)
             {
-                var a = _links[i].Split(new [] {'.'});
+                var a = _links[i].Split(new[] { '.' });
 
                 string tableName = string.Join(".", a.Take(a.Length - 1));
 

--- a/DataTables-Editor-Server/Upload.cs
+++ b/DataTables-Editor-Server/Upload.cs
@@ -321,12 +321,13 @@ namespace DataTables
 
                 if (prop is DbType)
                 {
-                    if ( (DbType)prop != DbType.Content && (DbType)prop != DbType.ContentBinary )
+                    if ((DbType)prop != DbType.Content && (DbType)prop != DbType.ContentBinary)
                     {
                         q.Get(column);
                     }
                 }
-                else {
+                else
+                {
                     q.Get(column);
                 }
             }
@@ -336,7 +337,7 @@ namespace DataTables
                 q.WhereIn(_dbPKey, ids);
             }
 
-            foreach ( var condition in _where )
+            foreach (var condition in _where)
             {
                 q.Where(condition);
             }
@@ -527,22 +528,20 @@ namespace DataTables
 
             string table;
             string field;
-            var a = fieldName.Split(new [] {'.'});
-
-            switch (a.Count())
+            var a = fieldName.Split(new[] { '.' });
+            if (a.Length == 1)
             {
-                case 1:
-                    table = editorTable;
-                    field = a[0];
-                    break;
-                case 2:
-                    table = a[0];
-                    field = a[1];
-                    break;
-                default:
-                    table = a[1];
-                    field = a[2];
-                    break;
+                table = editorTable;
+                field = a[0];
+            }
+            else
+            {
+                // editorTable can be Table or schema.Table
+                // fieldName can be Field (a.lenght == 1), Table.Field or schema.Table.Field
+                var editorTableName = editorTable.Split(new[] { '.' }).Last();
+                var fieldTableName = a.Length == 2 ? a[0] : a[1];
+                table = fieldTableName == editorTableName ? editorTable : string.Join(".", a.Take(a.Length - 1));
+                field = a.Last();
             }
 
             // Get the infromation from the database about the orphaned children
@@ -602,7 +601,7 @@ namespace DataTables
             // Insert the details requested, for the columns requested
             var q = db.Query("insert")
                 .Table(_dbTable)
-                .Pkey(new []{_dbPKey});
+                .Pkey(new[] { _dbPKey });
 
             foreach (var pair in _dbFields)
             {
@@ -678,7 +677,7 @@ namespace DataTables
                     {
                         // Callable function - execute to get the value
                         var propFn = (Func<Database, IFormFile, dynamic>)prop;
-                        
+
                         pathFields.Add(column, propFn(db, upload));
                         q.Set(column, "-"); // Use a temporary value (as above)
                     }


### PR DESCRIPTION
## UPLOAD
In DbClean it's assumed that the table specified in the field is a dbo-table, but it's not always true.

Here an example:
```csharp
new Editor(dtDatabase, "intranet.Links", "Id")
      .Field(new Field("Links.LinkIconId", "linkIconId")
          .SetFormatter(Format.IfEmpty(null))
          .Upload(
              new Upload(Path.Combine(environment.WebRootPath, "uploads", "links", "__ID____EXTN__"))
              .Validator(
                  Validation.FileExtensions(
                      new[] { "png", "jpg", "jpeg", "svg", "gif" },
                      "Carica un'immagine (png, jpg, gif o svg)"
                  )
              )
              .Db("intranet.LinkIcons", "Id", new Dictionary<string, object>
              {
                  {"FileName", Upload.DbType.FileName},
                  {"Extension", Upload.DbType.Extn},
                  {"FileSize", Upload.DbType.FileSize},
                  {"MimeType", Upload.DbType.MimeType},
                  {"WebPath", Path.Combine("uploads", "links", "__ID____EXTN__")},
                  {"SystemPath", Upload.DbType.SystemPath}
              })
              .DbClean(data =>
              {
                  foreach (var row in data)
                  {
                      System.IO.File.Delete(row["SystemPath"].ToString());
                  }
                  return true;
              })
          )
      )
```

## MJOIN

Same example:
```csharp
new Editor(dtDatabase, "intranet.Links", "Id")
        .MJoin(
            new MJoin("auth.Roles")
                .Link("intranet.Links.id", "intranet.LinkRoles.LinkId")
                .Link("auth.Roles.id", "intranet.LinkRoles.RoleId")
                .Order("auth.Roles.Name")
                .Field(new Field("Id", "id")
                    .Options("auth.Roles", "Id", "Name")
                )
                .Field(new Field("Roles.Name", "name"))
        )
```
Table name should be only Roles not auth.Roles. Otherwise it will be considered a normal joined table (in the request) and "Roles-many-count" key won't be calculated.

