### PR TITLE
Add support for using Enums as options for SearchPanes, SearchBuilder and Options

### DIFF
--- a/DataTables-Editor-Server/EditorUtil/Enums.cs
+++ b/DataTables-Editor-Server/EditorUtil/Enums.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace DataTables.EditorUtil
@@ -15,13 +16,21 @@ namespace DataTables.EditorUtil
             var underlyingType = Enum.GetUnderlyingType(typeof(T));
             if (useValueAsKey) {
                 return Enum.GetValues(typeof(T))
-                    .Cast<T>()
-                    .ToDictionary(e => Convert.ChangeType(e, underlyingType).ToString(), e => e.ToString());
+                    .Cast<object>()
+                    .ToDictionary(e => Convert.ChangeType(e, underlyingType).ToString(), e => GetEnumDescription((Enum)e));
             }
 
             return Enum.GetValues(typeof(T))
-                .Cast<T>()
-                .ToDictionary(e => e.ToString(), e => e.ToString());
+                .Cast<object>()
+                .ToDictionary(e => e.ToString(), e => GetEnumDescription((Enum)e));
+        }
+        private static string GetEnumDescription(Enum value)
+        {
+            var fieldInfo = value.GetType().GetField(value.ToString());
+            if (fieldInfo == null) return value.ToString();
+
+            var attribute = (DescriptionAttribute)Attribute.GetCustomAttribute(fieldInfo, typeof(DescriptionAttribute));
+            return attribute?.Description ?? value.ToString();
         }
     }
 }

--- a/DataTables-Editor-Server/EditorUtil/Enums.cs
+++ b/DataTables-Editor-Server/EditorUtil/Enums.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DataTables.EditorUtil
+{
+    internal class Enums
+    {
+        internal static Dictionary<string, string> ConvertToStringDictionary<T>(bool useValueAsKey)
+        {
+            if (!typeof(T).IsEnum) {
+                throw new ArgumentException(typeof(T).Name + " must be an enum type.");
+            }
+
+            var underlyingType = Enum.GetUnderlyingType(typeof(T));
+            if (useValueAsKey) {
+                return Enum.GetValues(typeof(T))
+                    .Cast<T>()
+                    .ToDictionary(e => Convert.ChangeType(e, underlyingType).ToString(), e => e.ToString());
+            }
+
+            return Enum.GetValues(typeof(T))
+                .Cast<T>()
+                .ToDictionary(e => e.ToString(), e => e.ToString());
+        }
+    }
+}

--- a/DataTables-Editor-Server/Options.cs
+++ b/DataTables-Editor-Server/Options.cs
@@ -55,32 +55,6 @@ namespace DataTables
         }
 
         /// <summary>
-        /// Add a manually defined option to the list from the database
-        /// </summary>
-        /// <param name="label">Label</param>
-        /// <param name="value">Value</param>
-        /// <returns>Self for chaining</returns>
-        public Options AddFromEnum<T>(bool useValueAsKey = true)
-        {
-            foreach (var pair in Enums.ConvertToStringDictionary<T>(useValueAsKey))
-            {
-                if (int.TryParse(pair.Key, out var valueInt)) {
-                    _manualOpts.Add(new Dictionary<string, object> {
-                        { "value", valueInt },
-                        { "label", pair.Value }
-                    });
-                }
-                else {
-                    _manualOpts.Add(new Dictionary<string, object> {
-                        { "value", pair.Key },
-                        { "label", pair.Value }
-                    });
-                }
-            }
-
-            return this;
-        }
-        /// <summary>
         /// Get the column name(s) for the options label
         /// </summary>
         /// <returns>Column name(s)</returns>
@@ -271,20 +245,6 @@ namespace DataTables
         /// <returns>List of options</returns>
         internal List<Dictionary<string, object>> Exec(Database db)
         {
-            //if no table provided, return only the manual options
-            if (_table == null) {
-                var manualOutput = new List<Dictionary<string, object>>();
-                _manualOpts.ToList().ForEach(opt => {
-                    manualOutput.Add(opt);
-                });
-
-                if (_order == null) {
-                    manualOutput.Sort((a, b) => a["label"].ToString().CompareTo(b["label"].ToString()));
-                }
-
-                return manualOutput.ToList();
-            }
-            
             var formatter = _renderer ?? (row =>
             {
                 var list = new List<string>();
@@ -340,15 +300,10 @@ namespace DataTables
                 {"label", formatter(row)}
             }).ToList();
 
-            if (_manualOpts.Count > 0) {
-                //Add manual options to the list from DB and then filter out duplicates by value.
-                _manualOpts.ToList().ForEach(opt => {
-                    output.Add(opt);
-                });
-                output = output.GroupBy(d => d["value"])
-                    .Select(g => g.First())
-                    .ToList();
-            }
+            _manualOpts.ToList().ForEach(opt =>
+            {
+                output.Add(opt);
+            });
 
             if (_order == null)
             {

--- a/DataTables-Editor-Server/Options.cs
+++ b/DataTables-Editor-Server/Options.cs
@@ -338,10 +338,15 @@ namespace DataTables
                 {"label", formatter(row)}
             }).ToList();
 
-            _manualOpts.ToList().ForEach(opt =>
-            {
-                output.Add(opt);
-            });
+            if (_manualOpts.Count > 0) {
+                //Add manual options to the list from DB and then filter out duplicates by value.
+                _manualOpts.ToList().ForEach(opt => {
+                    output.Add(opt);
+                });
+                output = output.GroupBy(d => d["value"])
+                    .Select(g => g.First())
+                    .ToList();
+            }
 
             if (_order == null)
             {

--- a/DataTables-Editor-Server/Options.cs
+++ b/DataTables-Editor-Server/Options.cs
@@ -55,6 +55,32 @@ namespace DataTables
         }
 
         /// <summary>
+        /// Add a manually defined option to the list from the database
+        /// </summary>
+        /// <param name="label">Label</param>
+        /// <param name="value">Value</param>
+        /// <returns>Self for chaining</returns>
+        public Options AddFromEnum<T>(bool useValueAsKey = true)
+        {
+            foreach (var pair in Enums.ConvertToStringDictionary<T>(useValueAsKey))
+            {
+                if (int.TryParse(pair.Key, out var valueInt)) {
+                    _manualOpts.Add(new Dictionary<string, object> {
+                        { "value", valueInt },
+                        { "label", pair.Value }
+                    });
+                }
+                else {
+                    _manualOpts.Add(new Dictionary<string, object> {
+                        { "value", pair.Key },
+                        { "label", pair.Value }
+                    });
+                }
+            }
+
+            return this;
+        }
+        /// <summary>
         /// Get the column name(s) for the options label
         /// </summary>
         /// <returns>Column name(s)</returns>
@@ -245,6 +271,20 @@ namespace DataTables
         /// <returns>List of options</returns>
         internal List<Dictionary<string, object>> Exec(Database db)
         {
+            //if no table provided, return only the manual options
+            if (_table == null) {
+                var manualOutput = new List<Dictionary<string, object>>();
+                _manualOpts.ToList().ForEach(opt => {
+                    manualOutput.Add(opt);
+                });
+
+                if (_order == null) {
+                    manualOutput.Sort((a, b) => a["label"].ToString().CompareTo(b["label"].ToString()));
+                }
+
+                return manualOutput.ToList();
+            }
+            
             var formatter = _renderer ?? (row =>
             {
                 var list = new List<string>();

--- a/DataTables-Editor-Server/Options.cs
+++ b/DataTables-Editor-Server/Options.cs
@@ -340,10 +340,15 @@ namespace DataTables
                 {"label", formatter(row)}
             }).ToList();
 
-            _manualOpts.ToList().ForEach(opt =>
-            {
-                output.Add(opt);
-            });
+            if (_manualOpts.Count > 0) {
+                //Add manual options to the list from DB and then filter out duplicates by value.
+                _manualOpts.ToList().ForEach(opt => {
+                    output.Add(opt);
+                });
+                output = output.GroupBy(d => d["value"])
+                    .Select(g => g.First())
+                    .ToList();
+            }
 
             if (_order == null)
             {

--- a/DataTables-Editor-Server/SearchBuilderOptions.cs
+++ b/DataTables-Editor-Server/SearchBuilderOptions.cs
@@ -23,6 +23,7 @@ namespace DataTables
         private Action<Query> _where;
         private string _order;
         private List<LeftJoin> _leftJoin = new List<LeftJoin>();
+        private Dictionary<string, string> _fromEnum = new Dictionary<string, string>();
 
         /// <summary>
         /// Get the column name(s) for the options label
@@ -179,6 +180,18 @@ namespace DataTables
             return this;
         }
 
+        /// <summary>
+        /// Set a function that will be used to apply an Enum to the SearchBuilder select
+        /// </summary>
+        /// <param name="useValueAsKey">Boolean to use the enum value as the key (default true)</param>
+        /// <returns>Self for chaining</returns>
+        public SearchBuilderOptions FromEnum<T>(bool useValueAsKey = true)
+        {
+            _fromEnum = Enums.ConvertToStringDictionary<T>(useValueAsKey);
+
+            return this;
+        }
+
         /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
          * Internal methods
          */
@@ -242,6 +255,12 @@ namespace DataTables
             var res = query.Exec()
                 .FetchAll();
 
+            // Replace labels from database with enum names, fall back on database values 
+            if (_fromEnum.Count > 0) {
+                foreach (var row in res) {
+                    row["label"] = _fromEnum[row["label"].ToString()] ?? row["label"].ToString();
+                }
+            }
 
     	    // Create output object with all of the SearchBuilderOptions
             List<Dictionary<string, object>> output = new List<Dictionary<string, object>>();

--- a/DataTables-Editor-Server/SearchBuilderOptions.cs
+++ b/DataTables-Editor-Server/SearchBuilderOptions.cs
@@ -181,7 +181,7 @@ namespace DataTables
         }
 
         /// <summary>
-        /// Set a function that will be used to apply an Enum to the SearchBuilder select
+        /// Set an enum that will be used to apply items to the SearchBuilder select
         /// </summary>
         /// <param name="useValueAsKey">Boolean to use the enum value as the key (default true)</param>
         /// <returns>Self for chaining</returns>

--- a/DataTables-Editor-Server/SearchPaneOptions.cs
+++ b/DataTables-Editor-Server/SearchPaneOptions.cs
@@ -181,7 +181,7 @@ namespace DataTables
         }
 
         /// <summary>
-        /// Set a function that will be used to apply an Enum to the SearchPanes select
+        /// Set an enum that will be used to apply items to the SearchPanes select
         /// </summary>
         /// <param name="useValueAsKey">Boolean to use the enum value as the key (default true)</param>
         /// <returns>Self for chaining</returns>


### PR DESCRIPTION
I was looking for a way to use an enum as a way to filter in SearchPanes, where my database stores only the int, but I want the user to be able to search using the name they are used to seeing elsewhere. In the end I added this functionality to SearchBuilder and Options as well.

### What's Added
I added a new class to `EditorUtil` called `Enums` that houses the method `ConvertToStringDictionary`. This takes care of converting the supplied enum to a `Dictionary<string, string>`. It also reads an optional Description attribute from the enum and uses that as the Value of the dictionary.  This checks to make sure the supplied item is an enum, and if not it throws an `ArgumentException(typeof(T).Name + " must be an enum type.")` . I did not figure out how to have this be a "nice" error, but on the other hand this is something that will break immediately when the dev first runs this.

### What's Changed
# SearchPaneOptions
I added `FromEnum<T>(bool useValueAsKey = true)` as a method to SearchPaneOptions. This method is supported by a new private field `_fromEnum` and is instantiated with a new Dictionary. 
In the `Exec` method, after the [valid options for a field are retrieved](https://github.com/gotmoo/Editor-NET/blob/02001841f96755de73c932a116fa785583d65e84/DataTables-Editor-Server/SearchPaneOptions.cs#L312), each row is looped and the label from the database is replaced with the name (or description) from the enum.

# SearchBuilderOptions
Pretty much a copy/paste from SearchPaneOptions, I added `FromEnum<T>(bool useValueAsKey = true)` as a method to SearchBuilderOptions. This method is supported by a new private field `_fromEnum` and is instantiated with a new Dictionary. 
In the `Exec` method, after the [valid options for a field are retrieved](https://github.com/gotmoo/Editor-NET/blob/02001841f96755de73c932a116fa785583d65e84/DataTables-Editor-Server/SearchBuilderOptions.cs#L258), each row is looped and the label from the database is replaced with the name (or description) from the enum.

# Options
in Options, I've added the `AddFromEnum<T>(bool useValueAsKey = true)` method. This method adds each item from the enum to `_manualOpts`, but not before checking if the value could be an integer.

Then I added a check at the [beginning of the `Exec` method](https://github.com/gotmoo/Editor-NET/blob/02001841f96755de73c932a116fa785583d65e84/DataTables-Editor-Server/Options.cs#L274) to see if the _table is null and just return the manual options after a quick sort.

If the table is supplied with value and label I noticed duplicate values once the manual options were added, so I [added](https://github.com/gotmoo/Editor-NET/blob/02001841f96755de73c932a116fa785583d65e84/DataTables-Editor-Server/Options.cs#L343) a check for `_manualOpts` presence and then remove duplicates based on the value.

### Usage
This example uses the `users` table with the `UploadManyModel`. I stared with the SearchBuilder example
```csharp
.Field(new Field("users.site")
    .SearchBuilderOptions(new SearchBuilderOptions()
        .FromEnum<SitesEnum>()
    )
    .SearchPaneOptions(new SearchPaneOptions()
        .FromEnum<SitesEnum>()
    )
    .Options(new Options()
        .AddFromEnum<SitesEnum>()
        .Add("Unknown", 0)
    )
)
.Field(new Field("users.title")
    .SearchBuilderOptions(new SearchBuilderOptions()
        .FromEnum<Salutations>(false) //use the name of the enum as value
    )
    .SearchPaneOptions(new SearchPaneOptions()
        .FromEnum<Salutations>(false)
    )
    .Options(new Options()
        .AddFromEnum<Salutations>(false)
    )
)
```
Example of an input enum:
```csharp
public enum SitesEnum
{
    Edinburgh = 1,
    London = 2,
    Paris = 3,
    [Description("New York")]
    NewYork = 4,
    Singapore = 5,
    [Description("Los Angeles")]
    LosAngeles = 6,
    Pittsburgh = 7
}
public enum Salutations
{
    Mr,
    Mrs,
    Ms,
    Miss,
    Dr,
    Sir,
    [Description("Ma'am")]
    Madam
}
```

Running this generates these options:
![image](https://github.com/DataTables/Editor-NET/assets/25994839/866879b7-3dc5-4925-a7e3-e39295b6b430)

and these builders:
![image](https://github.com/DataTables/Editor-NET/assets/25994839/8992b9e0-a898-4609-859d-5a8d11071b10)

I hope this helps explain what I did. I will be happy to answer further questions, or of any changes are needed to properly fit in the style of the project.

Thanks!

