### PR TITLE
Fix SearchPanes and SearchBuilder not pre-filtering data

### DIFF
--- a/DataTables-Editor-Server/Editor.cs
+++ b/DataTables-Editor-Server/Editor.cs
@@ -1179,6 +1179,13 @@ namespace DataTables
             return _request;
         }
 
+        /// <summary>
+        /// Apply the global Where filter to the supplied Query
+        /// </summary>
+        internal void GetGlobalWhere(Query query)
+        {
+            _GetWhere(query);
+        }
 
         /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
          * Private methods

--- a/DataTables-Editor-Server/SearchBuilderOptions.cs
+++ b/DataTables-Editor-Server/SearchBuilderOptions.cs
@@ -244,7 +244,8 @@ namespace DataTables
             var query = db.Query("select")
                 .Table(this._table)
                 .LeftJoin(_leftJoin);
-            
+            editor.GetGlobalWhere(query);
+
             if(fieldIn.Apply("get") && fieldIn.GetValue() == null){
                 query
                     .Get(this._value + " as value")

--- a/DataTables-Editor-Server/SearchPaneOptions.cs
+++ b/DataTables-Editor-Server/SearchPaneOptions.cs
@@ -280,6 +280,7 @@ namespace DataTables
                 .GroupBy(value)
                 .Where(_where)
                 .LeftJoin(join);
+            editor.GetGlobalWhere(q);
 
             if (viewTotal) {
                 q.Get("COUNT(*) as total");
@@ -330,6 +331,7 @@ namespace DataTables
                     .Distinct(true)
                     .Table(table)
                     .LeftJoin(join);
+                editor.GetGlobalWhere(entriesQuery);
 
                 if (fieldIn.Apply("get") && fieldIn.GetValue() == null) {
                     gettingCount = true;


### PR DESCRIPTION
fixes #11 

This is my take on having SearchPanes and SearchBuilder handle a pre-filtered setup for editor.

1st, in `editor.cs`, expose the _GetWhere method internally:
```csharp
/// <summary>
/// Apply the global Where filter to the supplied Query
/// </summary>
internal void GetGlobalWhere(Query query)
{
    _GetWhere(query);
}
```
Then in SearchPaneOptions, apply the filtering twice by calling the above function with the query:
```csharp
var q = db.Query("select")
    .Distinct(true)
    .Table(table)
    .Get(label + " as label")
    .Get(value + " as value")
    .GroupBy(value)
    .Where(_where)
    .LeftJoin(join);
editor.GetGlobalWhere(q);
```
and again later:
```csharp
var entriesQuery = db.Query("select")
    .Distinct(true)
    .Table(table)
    .LeftJoin(join);
editor.GetGlobalWhere(entriesQuery);
```
Similarly, in SearchBuilder:
```csharp
var query = db.Query("select")
    .Table(this._table)
    .LeftJoin(_leftJoin);
editor.GetGlobalWhere(query);
```