### PR TITLE
Tory.berra/fix/invalid group clause

### DIFF
--- a/DataTables-Editor-Server/Field.cs
+++ b/DataTables-Editor-Server/Field.cs
@@ -739,7 +739,7 @@ namespace DataTables
         /// Called by the Editor / Join class instances - not expected for general
         /// consumption - internal.
         /// </summary>
-        /// <param name="action">Direction that the data is travelling  - 'get' is reading DB data, `create` and `edit` for writing to the DB</param>
+        /// <param name="action">Direction that the data is traveling  - 'get' is reading DB data, `create` and `edit` for writing to the DB</param>
         /// <param name="data">Data submitted from the client-side when setting.</param>
         /// <returns>true if the field should be used in the get / set.</returns>
         internal bool Apply(string action, Dictionary<string, object> data = null)

--- a/DataTables-Editor-Server/SearchBuilderOptions.cs
+++ b/DataTables-Editor-Server/SearchBuilderOptions.cs
@@ -245,11 +245,11 @@ namespace DataTables
                 .Table(this._table)
                 .LeftJoin(_leftJoin);
             
-            if(fieldIn.Apply("get") && fieldIn.GetValue() == null){
+            if(fieldIn.Apply("get") && fieldIn.GetValue() == null) {
                 query
                     .Get(this._value + " as value")
                     .Get(_label + " as label")
-                    .GroupBy(this._value);
+                    .GroupBy(this._value + ", " + _label);
             }
 
             var res = query.Exec()

--- a/DataTables-Editor-Server/SearchPaneOptions.cs
+++ b/DataTables-Editor-Server/SearchPaneOptions.cs
@@ -277,7 +277,7 @@ namespace DataTables
                 .Table(table)
                 .Get(label + " as label")
                 .Get(value + " as value")
-                .GroupBy(value)
+                .GroupBy(value + ", " + label)
                 .Where(_where)
                 .LeftJoin(join);
 


### PR DESCRIPTION
Fixes https://github.com/DataTables/Editor-NET/issues/18

Editor .NET needs to include both value and label in the group clause. With SqlServer, you will get "Column '[sites].[x]' is invalid in the select list because it is not contained in either an aggregate function or the GROUP BY clause." if you provide two different columns (IE site.id and site.name).

I tested this on SQL Server, MySQL, Postgres, SQLite. Not Oracle but their docs show the same GROUP BY syntax as others...

Should not break backwards compatibility. I also tested using the same column in the GROUP BY clause twice, IE:

```sql
SELECT site.name AS value, site.name AS label
FROM sites
GROUP BY site.name, site.name
```

Works great across all RDBMSes.