### PR TITLE
use correct framework

### DIFF
--- a/DataTables-Editor-Server/DataTables-Editor-Server.csproj
+++ b/DataTables-Editor-Server/DataTables-Editor-Server.csproj
@@ -67,7 +67,7 @@ The software available in this package, acts as server-side libraries for Editor
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.5.0</Version>

--- a/DataTables-Editor-Server/DataTables-Editor-Server.csproj
+++ b/DataTables-Editor-Server/DataTables-Editor-Server.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net80;netcoreapp2.1;net45;net46;net47;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;netcoreapp2.1;net45;net46;net47;net48</TargetFrameworks>
     <Version >2.3.2</Version>
     <Authors>SpryMedia Ltd</Authors>
     <Product>DataTables Editor - server-side libraries for .NET</Product>
@@ -67,7 +67,7 @@ The software available in this package, acts as server-side libraries for Editor
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net80'">
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.5.0</Version>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks